### PR TITLE
closing existing connection if another connection is established.

### DIFF
--- a/solmate_sdk/apiclient.py
+++ b/solmate_sdk/apiclient.py
@@ -53,6 +53,9 @@ class SolMateAPIClient:
 
     async def _connect(self):
         """Asynchronously attempts to connect to the server and initialize the client."""
+        if self.conn is not None:
+            await self.conn.close()
+
         sock = await websockets.client.connect(self.uri)
         self.conn = SolConnection(sock)
 


### PR DESCRIPTION
This is needed when redirected for example. Due to this bug, a websocket connection is kept alive at the Sol until the client program is finished.